### PR TITLE
Set last-refresh-date-format action input

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           user-id: ${{ secrets.NISSAN_CONNECT_USER_ID }}
           password: ${{ secrets.NISSAN_CONNECT_PASSWORD }}
+          last-refresh-date-format: "ddd M/D h:mm A"
           debug-out: ${{ env.DEBUG_OUTPUT_FOLDER }}
       - uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
Starts using the new `last-refresh-date-format` action input. This parameter specifies the date format "ddd M/D h:mm A" (e.g., "Mon 1/15 9:30 AM") for the last refresh date in the workflow.