### PR TITLE
Update cron schedule and add blog post link to README

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,7 +1,9 @@
 name: Nissan Leaf Widget Updater
 on:
   schedule:
-    - cron: "5 0-7,13-23 * * *" # At minute 5 every hour between 6 am PT and midnight PT, inclusive
+    # GitHub interprets this schedule in UTC
+    - cron: "5 13 * * *" # 6:05 am PT
+    - cron: "5 1 * * *" # 6:05 pm PT
   workflow_dispatch:
 concurrency:
   group: hard-coded-so-only-one-instance-of-this-workflow-runs-at-a-time

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ This repo:
 
 1. calls the [reusable GitHub Action](https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions) from https://github.com/kevincon/nissan-connect-scraper to scrape information about my [Nissan LEAF®](https://en.wikipedia.org/wiki/Nissan_Leaf) vehicle from the [NissanConnect® Android app](https://play.google.com/store/apps/details?id=com.aqsmartphone.android.nissan)
 1. sends that information to an [IFTTT applet](https://ifttt.com/explore/ifttt_applets) that displays it in a [IFTTT home screen widget](https://ifttt.com/explore/how-to-use-widgets-ios) on my iPhone
+
+See [this blog post](https://kevintechnology.com/posts/leaf-widget/) for more information.


### PR DESCRIPTION
Reduced GitHub Action schedule to run twice daily (just to reduce any risk of draining the 12V battery) and added blog post reference.