### PR TITLE
Change Mergify merge method from merge to squash

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,4 +6,4 @@ pull_request_rules:
       - title=[pre-commit.ci] pre-commit autoupdate
     actions:
       merge:
-        method: merge
+        method: squash


### PR DESCRIPTION
Change Mergify's merge method from "merge" to "squash" for pre-commit autoupdate PRs.