### PR TITLE
Fail sooner if Android device is offline

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -28,7 +28,9 @@ jobs:
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
           tags: ${{ secrets.TAILSCALE_TAGS }}
       - name: Connect to Android device
-        run: adb connect ${{ secrets.ANDROID_DEVICE_ADB_ADDRESS }}
+        run: |
+          adb connect ${{ secrets.ANDROID_DEVICE_ADB_ADDRESS }}
+          [[ $(adb get-state) == "device" ]]
       - name: Run and Scrape Nissan Connect
         id: scrape
         uses: kevincon/nissan-connect-scraper@v1


### PR DESCRIPTION
Interestingly, `adb connect` returns a successful exit code if it times out trying to connect to a device over Tailscale:

<img width="469" alt="image" src="https://github.com/user-attachments/assets/294e30db-9b9c-4d54-8eb6-9665c9a78e0e" />

This PR adds an additional check that we actually connected to a device so the job will fail then if the device is offline instead of later as part of trying to use the device.